### PR TITLE
v1.6.1

### DIFF
--- a/objects/o_window/Create_0.gml
+++ b/objects/o_window/Create_0.gml
@@ -4,3 +4,5 @@ sineyoff = 0
 shake = 0
 surf_border = -1
 surf_prev = -1
+
+depth = DEPTH_UI.CONSOLE - 20 // make sure it's drawn last

--- a/objects/o_window/Draw_75.gml
+++ b/objects/o_window/Draw_75.gml
@@ -1,0 +1,18 @@
+if global.border {
+    if !surface_exists(surf_border)
+        surf_border = surface_create(960, 540)
+    surface_set_target(surf_border)
+    draw_clear_alpha(0,0)
+    
+    if is_struct(global.border_struct)
+        global.border_struct._drawer(960, 540, 1)
+    
+    gpu_set_blendmode(bm_subtract)
+    draw_rectangle(960/2 - 320, 540/2 - 240, 960/2 + 320 - 1, 540/2 + 240 - 1, false) // the cut-out
+    gpu_set_blendmode(bm_normal)
+    surface_reset_target()
+    
+    if surface_exists(surf_prev) && global.border_trans < 1
+        draw_surface_ext(surf_prev, 320 - 960/2, 240 - 540/2, 1, 1, 0, c_white, 1 - global.border_trans)
+    draw_surface_ext(surf_border, 320 - 960/2, 240 - 540/2, 1, 1, 0, c_white, global.border_trans)
+}

--- a/objects/o_window/Draw_77.gml
+++ b/objects/o_window/Draw_77.gml
@@ -23,22 +23,6 @@ gpu_set_blendmode(bm_normal)
 draw_clear(c_black)
 display_set_gui_maximize(scale, scale, xx + xoff - 640/2*scale, yy + yoff - 480/2*scale)
 
-if global.border {
-    if !surface_exists(surf_border)
-        surf_border = surface_create(screen_w, screen_h)
-    surface_set_target(surf_border)
-    draw_clear_alpha(0,0)
-    
-    if is_struct(global.border_struct)
-        global.border_struct._drawer(screen_w, screen_h, 1)
-    
-    surface_reset_target()
-    
-    if surface_exists(surf_prev) && global.border_trans < 1
-        draw_surface_ext(surf_prev, 0, 0, 1, 1, 0, c_white, 1 - global.border_trans)
-    draw_surface_ext(surf_border, 0, 0, 1, 1, 0, c_white, global.border_trans)
-}
-
 gpu_set_blendenable(false)
 draw_surface_ext(application_surface, 
     xx + xoff - 640/2*scale, yy + yoff - 480/2*scale, 

--- a/objects/o_window/o_window.yy
+++ b/objects/o_window/o_window.yy
@@ -6,6 +6,7 @@
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":0,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":0,"eventType":3,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
     {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":76,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
+    {"$GMEvent":"v1","%Name":"","collisionObjectId":null,"eventNum":75,"eventType":8,"isDnD":false,"name":"","resourceType":"GMEvent","resourceVersion":"2.0",},
   ],
   "managed":true,
   "name":"o_window",

--- a/objects/o_world/Other_2.gml
+++ b/objects/o_world/Other_2.gml
@@ -22,7 +22,7 @@ if !allow_incompatible_saves {
 		divide = 960
     
 	window_scale = floor( min(display_get_width() - 100, display_get_height() - 100) / divide )
-    fullscreen_scale = floor( min(display_get_width(), display_get_height()) / divide )
+    fullscreen_scale = min(display_get_width(), display_get_height()) / divide
     
     borders_toggle(global.border_mode != BORDER_MODE.OFF)
     borders_window_resize()

--- a/objects/o_world/Step_0.gml
+++ b/objects/o_world/Step_0.gml
@@ -5,11 +5,10 @@ if incompatible_end_cutscene
 
 if keyboard_check_pressed(vk_f2)
 	game_restart()
-if keyboard_check_pressed(vk_f4)
+if keyboard_check_pressed(vk_f4) {
 	window_set_fullscreen(!window_get_fullscreen())
-
-if keyboard_check_pressed(vk_f3) { // debug
-    borders_toggle()
+    if !window_get_fullscreen()
+        window_center()
 }
 
 // always set the music emitter volume

--- a/scripts/borders/borders.gml
+++ b/scripts/borders/borders.gml
@@ -69,6 +69,12 @@ function border_set(_border, _force = false) {
         surface_reset_target()
         
         surface_copy(surf_prev, 0, 0, surf_border)
+        
+        surface_set_target(surf_prev)
+        gpu_set_blendmode(bm_subtract)
+        draw_rectangle(960/2 - 320, 540/2 - 240, 960/2 + 320 - 1, 540/2 + 240 - 1, false) // the cut-out
+        gpu_set_blendmode(bm_normal)
+        surface_reset_target()
     }
     
     global.border_struct = new _border() // update the border struct

--- a/scripts/engine_info/engine_info.gml
+++ b/scripts/engine_info/engine_info.gml
@@ -1,4 +1,4 @@
-#macro ENGINE_VERSION "v1.6.0"
+#macro ENGINE_VERSION "v1.6.1"
 #macro ENGINE_NAME "tlDR Engine"
 #macro ENGINE_LAST_COMPATIBLE_VERSION "v1.2.0" // last compatible save version
 


### PR DESCRIPTION
borders:
- removed a debug feature for the borders - by pressing f3 you could toggle borders on/off (accidentally left that in last time)
- moved border rendering to gui end - now the borders draw OVER the application surface and leave a cut-out for it. functionally the same, but removes the possibility of things rendering on top of borders
- made sure that the fullscreen application surface always fills the whole window (used to be rounded down, but now it's percise. possible mixels though?)

misc:
- made it so the window becomes centered when going out of fullscreen (QOL)