### PR TITLE
Climb tweaks

### DIFF
--- a/objects/o_camera/Step_0.gml
+++ b/objects/o_camera/Step_0.gml
@@ -9,10 +9,14 @@ if instance_exists(target) {
             var d = abs(dist / 20);
             d = clamp(d, 0, (d >= 2 ? 5 : 2));
             
-            var spd = lerp(.5, 2, d) * sign(dist);
+            var spd = lerp(1, 4, d) * sign(dist);
             
-            if abs(dist) < .5
-                x = target.x;
+            if abs(dist) < abs(spd*2){
+                if abs(dist) < abs(spd)
+                    x = target.x;
+                else
+                    x = x_real + (spd/2);
+            }
             else 
                 x = x_real + spd;
         }
@@ -28,11 +32,15 @@ if instance_exists(target) {
     if follow_y {
         if climb_check() {
             var dist = target.y - y_real;
-            var spd = lerp(.5, 2, clamp(abs(dist / 20), 0, 1)) * sign(dist);
+            var spd = lerp(1, 4, clamp(abs(dist / 20), 0, 1)) * sign(dist);
             
-            if abs(dist) < .5
-                y = target.y;
-            else 
+            if abs(dist) < abs(spd*2){
+                if abs(dist) < abs(spd)
+                    y = target.y;
+                else
+                    y = y_real + (spd/2);
+            }
+				else 
                 y = y_real + spd;
         }
         else

--- a/objects/o_dev_climb_controller/Create_0.gml
+++ b/objects/o_dev_climb_controller/Create_0.gml
@@ -14,6 +14,7 @@ leader_inv_max = 30;
 move_buffer = 0;
 current_direction = 90;
 last_horizontal_direction = 0;
+last_direction = 0;
 
 move_reach = 23;
 

--- a/objects/o_dev_climb_controller/Draw_0.gml
+++ b/objects/o_dev_climb_controller/Draw_0.gml
@@ -13,7 +13,7 @@ var dx = lengthdir_x(10, current_direction);
 var dy = lengthdir_y(10, current_direction);
 
 if jump_reach > 4
-    draw_sprite_ext(spr_climb_traj_hint, draw_get_index_looped(spr_climb_traj_hint), get_leader().x + dx, get_leader().y + dy - 1, 1, jump_reach / jump_reach_max, current_direction + 90, traj_color, 0.85 * fade_alpha);
+    draw_sprite_ext(spr_climb_traj_hint, draw_get_index_looped(spr_climb_traj_hint), get_leader().x + dx, get_leader().y + dy - 1, 1, jump_reach / clamp(jump_reach_max, 0, 50), current_direction + 90, traj_color, 0.85 * fade_alpha);
 
 var hint_color = merge_color(c_yellow, c_white, 0.4 + sine(3, .4, jump_reach/2));
 var hint_alpha = clamp(sine(14, 1, jump_reach/2), 0.1, 0.8) * fade_alpha;

--- a/objects/o_dev_climb_controller/Step_0.gml
+++ b/objects/o_dev_climb_controller/Step_0.gml
@@ -16,8 +16,31 @@ if climbing {
                 var x_move = InputX(INPUT_CLUSTER.NAVIGATION);
                 var y_move = InputY(INPUT_CLUSTER.NAVIGATION);
                 
-                if x_move != 0 || y_move != 0
-                    current_direction = snap(InputDirection(90, INPUT_CLUSTER.NAVIGATION), 90);
+                if x_move != 0 || y_move != 0 {
+                    var ___reach = InputCheck(INPUT_VERB.SELECT) ? jump_reach_max + 10 : move_reach;
+						  var ___jm = InputCheck(INPUT_VERB.SELECT) ? CLIMB_JUMP_MODE.FURTHEREST : CLIMB_JUMP_MODE.NEAREST;
+                    if InputCheck(INPUT_VERB.RIGHT) and InputCheck(INPUT_VERB.UP) {
+                    	if !__find_tile(___reach, 0, ___jm) and __find_tile(___reach, 90, ___jm) current_direction = 90;
+                    	else if __find_tile(___reach, 0, ___jm) and !__find_tile(___reach, 90, ___jm) current_direction = 0;
+                    	else if last_direction == 0 current_direction = 90 else current_direction = 0;
+                    }
+                    else if InputCheck(INPUT_VERB.LEFT) and InputCheck(INPUT_VERB.UP) {
+                    	if !__find_tile(___reach, 180, ___jm) and __find_tile(___reach, 90, ___jm) current_direction = 90;
+                    	else if __find_tile(___reach, 180, ___jm) and !__find_tile(___reach, 90, ___jm) current_direction = 180;
+                    	else if last_direction == 180 current_direction = 90 else current_direction = 180;
+                    }
+                    else if InputCheck(INPUT_VERB.RIGHT) and InputCheck(INPUT_VERB.DOWN) {
+                    	if !__find_tile(___reach, 0, ___jm) and __find_tile(___reach, 270, ___jm) current_direction = 270;
+                    	else if __find_tile(___reach, 0, ___jm) and !__find_tile(___reach, 270, ___jm) current_direction = 0;
+                    	else if last_direction == 0 current_direction = 270 else current_direction = 0;
+                    }
+                    else if InputCheck(INPUT_VERB.LEFT) and InputCheck(INPUT_VERB.DOWN) {
+                    	if !__find_tile(___reach, 180, ___jm) and __find_tile(___reach, 270, ___jm) current_direction = 270;
+                    	else if __find_tile(___reach, 180, ___jm) and !__find_tile(___reach, 270, ___jm) current_direction = 180;
+                    	else if last_direction == 180 current_direction = 270 else current_direction = 180;
+                    }
+                    else current_direction = snap(InputDirection(90, INPUT_CLUSTER.NAVIGATION), 90);
+                }
                 
                 // charge
                 if (InputCheck(INPUT_VERB.SELECT) && !InputCheck(INPUT_VERB.CANCEL) && jump_buffer <= 0 && !jump_canceled) || jump_timer > 0 {
@@ -131,8 +154,11 @@ if climbing {
                             bump_timer = bump_off_time;
                             bump_buffered_movement = undefined;
                             
+									 last_direction = current_direction;
                             if current_direction % 180 == 0
                                 last_horizontal_direction = current_direction;
+                            if current_direction % 180 == 90
+                                last_vertical_direction = current_direction;
                             
                             get_leader().sprite_index = get_leader().s_climb_charge_left;
                             if last_horizontal_direction == 0
@@ -163,8 +189,11 @@ if climbing {
                         move_buffer = 10;
                         jump_buffer = 0;
                         
+								last_direction = current_direction;
                         if current_direction % 180 == 0
-                            last_horizontal_direction = current_direction;
+                           last_horizontal_direction = current_direction;
+                        if current_direction % 180 == 90
+                           last_vertical_direction = current_direction;
                         
                         animate(get_leader().x, target_tile.x, 8, anime_curve.sine_out, get_leader(), "x");
                         animate(get_leader().y, target_tile.y + 2, 8, anime_curve.sine_out, get_leader(), "y");
@@ -182,8 +211,12 @@ if climbing {
                         bump_timer = bump_off_time;
                         bump_buffered_movement = undefined;
                         
+								
+								last_direction = current_direction;
                         if current_direction % 180 == 0
-                            last_horizontal_direction = current_direction;
+                           last_horizontal_direction = current_direction;
+                        if current_direction % 180 == 90
+                           last_vertical_direction = current_direction;
                         
                         get_leader().sprite_index = get_leader().s_climb_charge_left;
                         if last_horizontal_direction == 0

--- a/objects/o_dev_climb_controller/Step_0.gml
+++ b/objects/o_dev_climb_controller/Step_0.gml
@@ -70,10 +70,15 @@ if climbing {
                     }
                     // animate them
                     get_leader().sprite_index = charge_sprite;
-                    get_leader().image_index = lerp(0, sprite_get_number(get_leader().sprite_index)-1, jump_reach/jump_reach_max);
+						  if jump_reach/clamp(jump_reach_max, 0, 50) > 2/3
+						      get_leader().image_index = 2;
+						  else if jump_reach/clamp(jump_reach_max, 0, 50) > 1/3
+						      get_leader().image_index = 1;
+                    else
+						      get_leader().image_index = 0;
                     
                     // player charge indicator
-                    if jump_reach/jump_reach_max > 2/3 {
+                    if jump_reach/clamp(jump_reach_max, 0, 50) > 2/3 {
                         get_leader().override_blend = merge_color(get_leader().image_blend, c_teal, 0.4 + floor(sin(jump_timer)) * .4);
                         audio_sound_pitch(sfx_charge, .7);
                         
@@ -84,7 +89,7 @@ if climbing {
                             }
                         }
                     }
-                    else if jump_reach/jump_reach_max > 1/3 {
+                    else if jump_reach/clamp(jump_reach_max, 0, 50) > 1/3 {
                         get_leader().override_blend = merge_color(get_leader().image_blend, c_teal, 0.2 + floor(sin(jump_timer)) * .2);
                         audio_sound_pitch(sfx_charge, .5);
                     }

--- a/sprites/spr_climb_traj_hint/spr_climb_traj_hint.yy
+++ b/sprites/spr_climb_traj_hint/spr_climb_traj_hint.yy
@@ -27,7 +27,7 @@
   "name":"spr_climb_traj_hint",
   "nineSlice":{
     "$GMNineSliceData":"",
-    "bottom":0,
+    "bottom":5,
     "enabled":true,
     "guideColour":[4294902015,4294902015,4294902015,4294902015,],
     "highlightColour":1728023040,
@@ -43,7 +43,7 @@
       0,
       1,
     ],
-    "top":0,
+    "top":1,
   },
   "origin":9,
   "parent":{

--- a/sprites/spr_kris_climb_charge/spr_kris_climb_charge.yy
+++ b/sprites/spr_kris_climb_charge/spr_kris_climb_charge.yy
@@ -61,7 +61,7 @@
     },
     "name":"spr_kris_climb_charge",
     "playback":1,
-    "playbackSpeed":3.0,
+    "playbackSpeed":0.0,
     "playbackSpeedType":0,
     "resourceType":"GMSequence",
     "resourceVersion":"2.0",

--- a/sprites/spr_kris_climb_charge_left/spr_kris_climb_charge_left.yy
+++ b/sprites/spr_kris_climb_charge_left/spr_kris_climb_charge_left.yy
@@ -61,7 +61,7 @@
     },
     "name":"spr_kris_climb_charge_left",
     "playback":1,
-    "playbackSpeed":3.0,
+    "playbackSpeed":0.0,
     "playbackSpeedType":0,
     "resourceType":"GMSequence",
     "resourceVersion":"2.0",

--- a/sprites/spr_kris_climb_charge_right/spr_kris_climb_charge_right.yy
+++ b/sprites/spr_kris_climb_charge_right/spr_kris_climb_charge_right.yy
@@ -61,7 +61,7 @@
     },
     "name":"spr_kris_climb_charge_right",
     "playback":1,
-    "playbackSpeed":3.0,
+    "playbackSpeed":0.0,
     "playbackSpeedType":0,
     "resourceType":"GMSequence",
     "resourceVersion":"2.0",


### PR DESCRIPTION
Tweaks to climbing:
- Climb camera moves faster.
- Multi-Key direction behavior: Holding multiple keys in a general direction will alternate between the two directions, allowing diagonal-like movement. You'll also no longer constantly bump while holding multiple keys against the climbable boundaries.
- Charge animation sync.
- Allowed some support for jump_reach_max values above 50 by clamping it where needed.