### PR TITLE
Light world menu top box positioning

### DIFF
--- a/objects/o_ui_menu_lw/Draw_64.gml
+++ b/objects/o_ui_menu_lw/Draw_64.gml
@@ -1,4 +1,10 @@
 { // top
+	if instance_exists(get_leader()) {
+        yy = 0
+		if get_leader().y - guipos_y() > 160
+			yy = 270
+	}
+	
 	ui_dialoguebox_create(32, 52 + yy, 142, 110)
 	
 	draw_set_font(loc_font("main"))


### PR DESCRIPTION
Small thing I noticed in Deltarune that I also noticed wasn't in tldr

The player's stats box in the light world menu changes position based on the player's position

<img width="320" height="240" alt="image" src="https://github.com/user-attachments/assets/d996dc0e-747a-466d-b149-b0f78b93d29d" /> <img width="320" height="240" alt="image" src="https://github.com/user-attachments/assets/0de9fb2a-0f59-4174-a113-b8c5eac0f705" />
