### PR TITLE
Make light menu logic consistent with DELTARUNE

### DIFF
--- a/objects/o_ui_menu_lw/Create_0.gml
+++ b/objects/o_ui_menu_lw/Create_0.gml
@@ -3,7 +3,7 @@ if instance_exists(get_leader())
 
 yy = 0
 state = 0
-selection = 0
+selection = global.lw_selection
 dialogue_overlay = false
 
 ip_selection = 0
@@ -55,3 +55,4 @@ phone_cant_cutscene = function() {
     cutscene_func(instance_destroy, o_ui_menu_lw)
     cutscene_play()
 }
+audio_play(snd_ui_move)

--- a/objects/o_ui_menu_lw/Create_0.gml
+++ b/objects/o_ui_menu_lw/Create_0.gml
@@ -3,7 +3,7 @@ if instance_exists(get_leader())
 
 yy = 0
 state = 0
-selection = global.lw_selection
+selection = global.menu_page
 dialogue_overlay = false
 
 ip_selection = 0

--- a/objects/o_ui_menu_lw/Draw_64.gml
+++ b/objects/o_ui_menu_lw/Draw_64.gml
@@ -132,11 +132,15 @@ if state == 3 { // stats
 if state == 4 { // cell
     ui_dialoguebox_create(188, 52, 346, 270)
     
-    for (var i = 0; i < array_length(phone_numbers); i ++) {
-        var __number = phone_numbers[i]
+	if array_equals(phone_numbers, [])
+		draw_sprite_ext(spr_ui_soul, 0, 232-24, 88, 2, 2, 0, c_red, 1)
+	else {
+	    for (var i = 0; i < array_length(phone_numbers); i ++) {
+	        var __number = phone_numbers[i]
         
-        if c_selection == i
-            draw_sprite_ext(spr_ui_soul, 0, 232-24, 88+i*32, 2, 2, 0, c_red, 1)
-        draw_text_transformed(232, 80 + i*32, __number.name, 2, 2, 0)
-    }
+	        if c_selection == i
+	            draw_sprite_ext(spr_ui_soul, 0, 232-24, 88+i*32, 2, 2, 0, c_red, 1)
+	        draw_text_transformed(232, 80 + i*32, __number.name, 2, 2, 0)
+	    }
+	}
 }

--- a/objects/o_ui_menu_lw/Step_0.gml
+++ b/objects/o_ui_menu_lw/Step_0.gml
@@ -8,17 +8,17 @@ if dialogue_overlay {
 
 if state == 0 {
 	if InputPressed(INPUT_VERB.DOWN) {
-		selection ++
-		audio_play(snd_ui_move)
+		if selection < array_length(options)-1 {
+			selection ++
+			audio_play(snd_ui_move)
+		}
 	}
 	else if InputPressed(INPUT_VERB.UP) {
-		selection --
-		audio_play(snd_ui_move)
+		if selection > 0 {
+			selection --
+			audio_play(snd_ui_move)
+		}
 	}
-	if selection > array_length(options)-1
-		selection = 0
-	if selection < 0 
-		selection = array_length(options)-1
 	
 	if InputPressed(INPUT_VERB.CANCEL) || InputPressed(INPUT_VERB.SPECIAL) {
 		instance_destroy()
@@ -27,7 +27,6 @@ if state == 0 {
 	if InputPressed(INPUT_VERB.SELECT) {
 		if selection == 0 {
 			if item_get_count(ITEM_TYPE.LIGHT) == 0 {
-				audio_play(snd_ui_cant_select)
                 exit
             }
             
@@ -49,17 +48,20 @@ if state == 0 {
 if state == 1 {
 	if InputPressed(INPUT_VERB.DOWN){
 		i_selection ++
-		audio_play(snd_ui_move)
+		
+		if i_selection > item_get_count(ITEM_TYPE.LIGHT)-1
+			i_selection = item_get_count(ITEM_TYPE.LIGHT)-1
+		else
+			audio_play(snd_ui_move)
 	}
 	else if InputPressed(INPUT_VERB.UP){
 		i_selection --
-		audio_play(snd_ui_move)
+		
+		if i_selection < 0
+			i_selection = 0
+		else
+			audio_play(snd_ui_move)
 	}
-	
-	if i_selection > item_get_count(ITEM_TYPE.LIGHT)-1
-		i_selection = item_get_count(ITEM_TYPE.LIGHT)-1
-	if i_selection < 0
-		i_selection = 0
 		
 	if InputPressed(INPUT_VERB.SELECT){
 		state = 2
@@ -69,6 +71,10 @@ if state == 1 {
 	}
 	
 	if InputPressed(INPUT_VERB.CANCEL){
+		if i_selection != selection {
+			audio_play(snd_ui_move)
+		}
+		i_selection = 0
 		state = 0
 		exit
 	}
@@ -76,17 +82,20 @@ if state == 1 {
 if state == 2 {
 	if InputPressed(INPUT_VERB.RIGHT) {
 		ip_selection ++
-		audio_play(snd_ui_move)
+		
+		if ip_selection > 2
+			ip_selection = 2
+		else
+			audio_play(snd_ui_move)
 	}
 	else if InputPressed(INPUT_VERB.LEFT) {
 		ip_selection --
-		audio_play(snd_ui_move)
+		
+		if ip_selection < 0
+			ip_selection = 0
+		else
+			audio_play(snd_ui_move)
 	}
-	
-	if ip_selection > 2
-		ip_selection = 2
-	if ip_selection < 0
-		ip_selection = 0
 	
 	if InputPressed(INPUT_VERB.SELECT) {
 		var _item = item_get_array(ITEM_TYPE.LIGHT)[i_selection]
@@ -108,12 +117,16 @@ if state == 2 {
 	}
 	
 	if InputPressed(INPUT_VERB.CANCEL) {
+		if ip_selection != i_selection {
+			audio_play(snd_ui_move)
+		}
 		state = 1
 		exit
 	}
 }
 if state == 3 {
     if InputPressed(INPUT_VERB.CANCEL){
+		audio_play(snd_ui_move)
 		state = 0
 		exit
 	}
@@ -121,11 +134,15 @@ if state == 3 {
 if state == 4 {
     if InputPressed(INPUT_VERB.DOWN){
 		c_selection ++
-		audio_play(snd_ui_move)
+		
+		if c_selection < array_length(phone_numbers) - 1
+			audio_play(snd_ui_move)
 	}
 	else if InputPressed(INPUT_VERB.UP){
 		c_selection --
-		audio_play(snd_ui_move)
+		
+		if c_selection > 0
+			audio_play(snd_ui_move)
 	}
     c_selection = clamp(c_selection, 0, array_length(phone_numbers) - 1)
     
@@ -136,6 +153,9 @@ if state == 4 {
         exit
     }
     if InputPressed(INPUT_VERB.CANCEL){
+		if c_selection != selection {
+			audio_play(snd_ui_move)
+		}
 		state = 0
 		exit
 	}

--- a/objects/o_ui_menu_lw/Step_0.gml
+++ b/objects/o_ui_menu_lw/Step_0.gml
@@ -21,6 +21,7 @@ if state == 0 {
 	}
 	
 	if InputPressed(INPUT_VERB.CANCEL) || InputPressed(INPUT_VERB.SPECIAL) {
+		global.lw_selection = selection
 		instance_destroy()
 	}
 	
@@ -132,26 +133,29 @@ if state == 3 {
 	}
 }
 if state == 4 {
-    if InputPressed(INPUT_VERB.DOWN){
-		c_selection ++
+	if !array_equals(phone_numbers, []) {
+	    if InputPressed(INPUT_VERB.DOWN){
+			c_selection ++
 		
-		if c_selection < array_length(phone_numbers) - 1
-			audio_play(snd_ui_move)
-	}
-	else if InputPressed(INPUT_VERB.UP){
-		c_selection --
+			if c_selection < array_length(phone_numbers) - 1
+				audio_play(snd_ui_move)
+		}
+		else if InputPressed(INPUT_VERB.UP){
+			c_selection --
 		
-		if c_selection > 0
-			audio_play(snd_ui_move)
-	}
-    c_selection = clamp(c_selection, 0, array_length(phone_numbers) - 1)
+			if c_selection > 0
+				audio_play(snd_ui_move)
+		}
+	
+		c_selection = clamp(c_selection, 0, array_length(phone_numbers) - 1)
     
-    if InputPressed(INPUT_VERB.SELECT) {
-        phone_numbers[c_selection].cutscene()
-        dialogue_overlay = true
+	    if InputPressed(INPUT_VERB.SELECT) {
+	        phone_numbers[c_selection].cutscene()
+	        dialogue_overlay = true
         
-        exit
-    }
+	        exit
+	    }
+	}
     if InputPressed(INPUT_VERB.CANCEL){
 		if c_selection != selection {
 			audio_play(snd_ui_move)

--- a/objects/o_ui_menu_lw/Step_0.gml
+++ b/objects/o_ui_menu_lw/Step_0.gml
@@ -21,7 +21,7 @@ if state == 0 {
 	}
 	
 	if InputPressed(INPUT_VERB.CANCEL) || InputPressed(INPUT_VERB.SPECIAL) {
-		global.lw_selection = selection
+		global.menu_page = selection
 		instance_destroy()
 	}
 	

--- a/objects/o_world/Create_0.gml
+++ b/objects/o_world/Create_0.gml
@@ -123,6 +123,7 @@ global.recruits_lost = []
 
 global.storage = array_create(item_get_maxcount(ITEM_TYPE.STORAGE), undefined)
 
+global.lw_selection = 0
 global.lw_items = []
 global.lw_weapon = undefined
 global.lw_armor = undefined

--- a/objects/o_world/Create_0.gml
+++ b/objects/o_world/Create_0.gml
@@ -123,7 +123,6 @@ global.recruits_lost = []
 
 global.storage = array_create(item_get_maxcount(ITEM_TYPE.STORAGE), undefined)
 
-global.lw_selection = 0
 global.lw_items = []
 global.lw_weapon = undefined
 global.lw_armor = undefined


### PR DESCRIPTION
These changes make tldr's light world menu I think 100% accurate to how it works in DELTARUNE by changing:
- The logic behind when snd_ui_move is played
- How option selections function
- Removing snd_ui_cant_select when pressing select on the item option if it's disabled
- How having no phone numbers is handled

In DELTARUNE, snd_ui_move is played if when moving between menus the selected option in the currently entered menu is not the same selection number as the menu you are entering. It's also played when opening the lw menu and of course when moving between options in those menus, unless you have reached either end of those options.

The currently selected option is saved when closing and reopening the menu the same way it is in the dark world menu.

From what I've seen, trying to open the item menu when it's disabled doesn't play any sound unlike in tldr.

When opening the cell menu in DELTARUNE, if there are no phone numbers, it will simply place the soul in the spot where it would be if the first option was selected, with no further interactivity being available in the menu.

These are all the inaccuracies I've noticed in my experience with experimenting with this menu, feel free to point out anything wrong here.