### PR TITLE
Custom no-mercy text

### DIFF
--- a/scripts/enc_actions/enc_actions.gml
+++ b/scripts/enc_actions/enc_actions.gml
@@ -379,6 +379,9 @@ function enc_action_spare(_party_names, _enemy_target) : enc_action(_party_names
                         call_later(10, time_source_units_frames, function() {__e_obj.flash_color = c_white;});
                     }));
                 }
+				else { // cannot be spared
+					txt = __enemy.no_mercy_text;
+				}
                 
                 cutscene_dialogue(string(txt, party_getname(other.acting_member), __enemy.name),, true)
                 cutscene_set_variable(o_enc, "waiting_internal", false)

--- a/scripts/enc_enemies/enc_enemies.gml
+++ b/scripts/enc_enemies/enc_enemies.gml
@@ -15,6 +15,7 @@ function enemy() constructor {
 	mercy =	0
     mercy_add_pity_percent = 20
     can_spare = true
+	no_mercy_text = "* But you couldn't spare it, for some reason."
     
 	tired =	false
     low_hp_tired = true // whether the enemy should turn tired when hp is low

--- a/scripts/ex_enc_enemies/ex_enc_enemies.gml
+++ b/scripts/ex_enc_enemies/ex_enc_enemies.gml
@@ -137,6 +137,7 @@ function ex_enemy_spawnling() : enemy() constructor{
     
     can_spare = false
     mercy_add_pity_percent = 0
+	no_mercy_text = "* But, it was not something that can understand MERCY."
     
     // sprites
     s_idle = spr_ex_e_spawnling
@@ -172,6 +173,7 @@ function ex_enemy_dentos() : enemy() constructor{
     
     can_spare = false
     mercy_add_pity_percent = 0
+	no_mercy_text = "* But, it was not something that can understand MERCY."
 	
     // sprites
     s_idle = spr_ex_e_dentos


### PR DESCRIPTION
small change to the enemy() constructor and to enc_action_spare() to allow custom text for when the player is trying to spare an unspareable enemy (+ implementation in the spawnling+dentos example enc_set)