### PR TITLE
Change order of operations for can_preform and make check callable

### DIFF
--- a/scripts/enc_scripts/enc_scripts.gml
+++ b/scripts/enc_scripts/enc_scripts.gml
@@ -289,17 +289,14 @@ function enc_item_get_enabled(item_struct) {
         }
     }
     
+	if struct_exists(item_struct, "enabled") {
+        can_perform = variable_callable_to_value(item_struct.enabled)
+    }
+
     if struct_exists(item_struct, "tp_cost") {
         if item_struct.tp_cost > o_enc.tp
             can_perform = false
-    }
-    if struct_exists(item_struct, "enabled") {
-        if is_bool(item_struct.enabled)
-            can_perform = item_struct.enabled
-        else if is_callable(item_struct.enabled)
-            can_perform = item_struct.enabled
-    }
-    
+    }    
     return can_perform
 }
 

--- a/scripts/enc_scripts/enc_scripts.gml
+++ b/scripts/enc_scripts/enc_scripts.gml
@@ -294,7 +294,7 @@ function enc_item_get_enabled(item_struct) {
     }
 
     if struct_exists(item_struct, "tp_cost") {
-        if item_struct.tp_cost > o_enc.tp
+        if item_struct.tp_cost >= o_enc.tp
             can_perform = false
     }    
     return can_perform


### PR DESCRIPTION
tp cost should be the last thing to check, otherwise you can preform acts without having the requisite TP.  change to `variable_callable_to_value` enable callable