### PR TITLE
Pitch control in dialogue

### DIFF
--- a/objects/o_text_typer/Create_0.gml
+++ b/objects/o_text_typer/Create_0.gml
@@ -153,15 +153,20 @@ __play_voice = function(symbol, bypass_conditions = false) {
         // work on the pitch
         var __pitch_calc = struct_get(char_presets, char).voice_pitch_calc
         
-        if !is_undefined(voice_pitchrange)
-            pitch = random_range(
-                voice_pitchrange[0],
-                voice_pitchrange[1]
-            )
-        else if is_real(__pitch_calc)
+        if is_real(__pitch_calc)
             pitch = __pitch_calc
         else if is_method(__pitch_calc)
             pitch = __pitch_calc()
+		else { // idk why the pitch would ever be set to anything but a method/real but id rather catch exceptions like these
+			show_debug_message("WARNING: pitch defined as non-real/non-method. Pitch has been set to 1.");
+			pitch = 1;
+		}
+			
+		if !is_undefined(voice_pitchrange)
+            pitch *= random_range(
+                voice_pitchrange[0],
+                voice_pitchrange[1]
+            )
         
         // play unless it's a punctuation sign
         if struct_get(char_presets, char).voice != -1 && !array_contains(voice_skip_symbols, symbol)

--- a/objects/o_text_typer/Other_10.gml
+++ b/objects/o_text_typer/Other_10.gml
@@ -323,7 +323,7 @@ if command == "char" { // char(`char_preset_string`, face_expression = undefined
     	voice_pitch_calc = struct_get(struct_get(char_presets, arg[0]), "voice_pitch_calc")
     	voice_interrupt = struct_get(struct_get(char_presets, arg[0]), "voice_interrupt")
     	voice_skip = struct_get(struct_get(char_presets, arg[0]), "voice_skip")
-        voice_pitchrange = undefined
+        voice_pitchrange = struct_get(struct_get(char_presets, arg[0]), "voice_pitchrange")
         
         var __char_font = struct_get(struct_get(char_presets, arg[0]), "font");
         if !is_undefined(__char_font) {
@@ -365,6 +365,22 @@ if command == "voice" { // voice(asset OR nil, pitch_range = undefined, interrup
 		voice_interrupt = string_to_bool(arg[2])
 	if array_length(arg) > 3 && arg[3] != "nil" 
 		voice_skip = string_to_bool(arg[3])
+}
+
+if command == "pitch" { // pitch([val OR min], [max]) -- setting no arguments resets pitch
+	if array_length(arg) > 0 {
+		if array_length(arg) == 1
+		{
+			voice_pitchrange = [arg[0], arg[0]];
+		}
+		else {
+			voice_pitchrange = [arg[0], arg[1]];
+		}
+	}
+	else {
+		voice_pitchrange = undefined;
+	}
+	
 }
 
 if command == "mini" { // mini(`text`, char = undefined, face_expression = undefined, x = `auto`, y = `auto`)


### PR DESCRIPTION
- added {pitch} command to o_text_typer
- typer_char.voice_pitchrange was being ignored when loading a character preset with {char}
- handled an exception in o_text_typer.__play_voice() wherein it would (for some reason) not be a real number or a method
- lightly changed the way voice_pitchrange is handled in o_text_typer.__play_voice() so that it can work in tandem with typer_char.voice_pitch_calc()